### PR TITLE
Fix Dotenv loading

### DIFF
--- a/src/main/kotlin/vision/salient/Config.kt
+++ b/src/main/kotlin/vision/salient/Config.kt
@@ -4,13 +4,16 @@ import io.github.cdimascio.dotenv.Dotenv
 
 object Config {
 
-    // Load environment variables
-    private val dotenv = Dotenv.load()
+    // Load environment variables. Ignore missing or malformed .env files
+    private val dotenv = Dotenv.configure()
+        .ignoreIfMalformed()
+        .ignoreIfMissing()
+        .load()
     val deviceId = dotenv["DEVICE_ID"]
     val username: String? = dotenv["USERNAME"]
 
     // Paths
-    val basePath: String = dotenv["BASE_PATH"] ?: "/Users/${username}"
+    val basePath: String = dotenv["BASE_PATH"] ?: System.getProperty("user.home")
 
     // Snapshot paths
     val deviceSnapshotDir: String = dotenv["DEVICE_SNAPSHOT_DIR"] ?: "/sdcard/whats"


### PR DESCRIPTION
## Summary
- handle missing .env gracefully
- default BASE_PATH to user.home

## Testing
- `gradle build`
- `gradle run --args="--help"`


------
https://chatgpt.com/codex/tasks/task_e_684d2d87bb788326b8eb8df7bb46b88a